### PR TITLE
feat(flash): update confirmation to use flash

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -11,18 +11,26 @@ $(document).ready(function() {
     $.post("/addtohistory", {pet_name: petName, signed_request: signedRequest});
   });
 
+  var clearHistory = function() {
+    $.post("/clearhistory", {signed_request: signedRequest});
+    $(".js-pet-names a").remove();
+    $(".notice").show();
+  };
+
   Livestax.menu.set("Clear History", "eraser", function() {
+    var flashData = {
+      message: "Sure you want to clear your history?",
+      dismiss: function() {},
+      confirm: clearHistory
+    };
+
     var dialogData = {
       title: "Are you sure?",
       message: "Are you sure you want to clear your history? This is an irreversible action and cannot be undone.",
       buttons: [
         {
           title: "Yes",
-          callback: function(){
-            $.post("/clearhistory", {signed_request: signedRequest});
-            $(".js-pet-names a").remove();
-            $(".notice").show();
-          },
+          callback: clearHistory,
           type: "danger"
         },
         {
@@ -32,7 +40,8 @@ $(document).ready(function() {
         }
       ]
     };
-    Livestax.dialog.show(dialogData);
+    //Livestax.dialog.show(dialogData); //uncomment this if you want to use the dialog
+    Livestax.flash.danger(flashData); // uncomment this if you want to use the flash message
   });
 
   $(document.body).on("click", ".js-pet-names a", function(event) {


### PR DESCRIPTION
The confirmation before a history clear is now done using a flash
message. However, as the tutorial allows users to decide whether to use
a dialog or flash message, the code for the confirmation dialog has been
kept. The API call for the dialog, however, has been commented out.